### PR TITLE
Bump version from 1.5.10 to 1.5.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SNNModels"
 uuid = "5fb03681-66ea-42c3-a459-1265ed30d607"
-version = "1.5.10"
+version = "1.5.11"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
- bug fix in sparse matrix when connection probability is zero
- bug fix in STP
- bug fix in SpikeTimeStimulus distribution